### PR TITLE
Fix build issues after 13 years of rot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.scon*
+build
+rebound

--- a/SConstruct
+++ b/SConstruct
@@ -35,7 +35,7 @@ else:
 
 # Our library list is a static list so set it here
 libs  = ['SDLmain', 'SDL', 'SDL_image', 'SDL_ttf', 'SDL_mixer',
-         'boost_signals']
+         'boost_signals', 'boost_system']
 
 # Our cpp flags are also static for now, we may want to add options
 #  for debug later ex.: -O0 -g -pg

--- a/src/level.cpp
+++ b/src/level.cpp
@@ -6,15 +6,15 @@
 #include <sstream>
 
 // Boost
-#include <boost/spirit/core.hpp>
-#include <boost/spirit/iterator/file_iterator.hpp>
-#include <boost/spirit/utility/functor_parser.hpp>
-#include <boost/spirit/actor/assign_actor.hpp>
+#include <boost/spirit/include/classic_core.hpp>
+#include <boost/spirit/include/classic_iterator.hpp>
+#include <boost/spirit/include/classic_utility.hpp>
+#include <boost/spirit/include/classic_actor.hpp>
 
 // Rebound
 #include "exception.hpp"
 
-using namespace boost::spirit;
+using namespace boost::spirit::classic;
 using std::string;
 using std::stringstream;
 
@@ -314,7 +314,7 @@ namespace rebound {
 
     iterator_t end = infile.make_end();
 
-    parse_info<iterator_t> info = boost::spirit::parse(infile, end, lp, space_p);
+    parse_info<iterator_t> info = boost::spirit::classic::parse(infile, end, lp, space_p);
     
     if (!info.full) {
       stringstream sstr;


### PR DESCRIPTION
Updated boost include path and namespace (and library linker) to get it to run on Ubuntu 18.04.  There is still an issue with the parser and several other warnings that need to be fixed.